### PR TITLE
Add article sections and project filter

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { getArticleSlugs, getArticleBySlug } from '@/lib/articles';
 import type { Metadata } from 'next';
+import { ProfileCard } from '../components/ProfileCard';
+import { Badge } from '@/components/ui/badge';
 
 export async function generateStaticParams() {
   return getArticleSlugs().map((slug) => ({ slug }));
@@ -15,12 +17,17 @@ export default async function ArticlePage({ params }: { params: Promise<{ slug: 
   const { slug } = await params;
   const { meta, content } = await getArticleBySlug(slug);
   return (
-    <div className="px-4 py-8 max-w-prose mx-auto">
-      <h1 className="text-3xl font-bold mb-2">{meta.title}</h1>
-      <div className="text-sm text-muted-foreground mb-6">
-        {new Date(meta.date).toLocaleDateString('id-ID')}
+    <div className="px-4 py-8 max-w-prose mx-auto space-y-6">
+      <ProfileCard />
+      <div>
+        <h1 className="text-3xl font-bold mb-2">{meta.title}</h1>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+          <Badge variant="secondary">{meta.category}</Badge>
+          <span>{new Date(meta.date).toLocaleDateString('id-ID')}</span>
+        </div>
+        <img src={meta.thumbnail} alt="" className="w-full rounded-lg mb-4" />
+        <article className="prose prose-slate dark:prose-invert" dangerouslySetInnerHTML={{ __html: content }} />
       </div>
-      <article className="prose prose-slate dark:prose-invert" dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );
 }

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 import { getArticleMeta } from '@/lib/articles';
+import { ProfileCard } from '../components/ProfileCard';
+import { Badge } from '@/components/ui/badge';
 
 export const metadata = {
   title: 'Artikel',
@@ -8,17 +10,24 @@ export const metadata = {
 export default async function ArticlesPage() {
   const articles = getArticleMeta();
   return (
-    <div className="px-4 py-8 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Artikel</h1>
+    <div className="px-4 py-8 max-w-2xl mx-auto space-y-6">
+      <ProfileCard />
+      <h1 className="text-2xl font-bold">Artikel</h1>
       <ul className="space-y-4">
         {articles.map((article) => (
-          <li key={article.slug} className="border-b pb-4">
+          <li key={article.slug} className="border-b pb-4 space-y-1">
             <Link
               href={`/articles/${article.slug}`}
               className="text-primary font-semibold text-lg hover:underline"
             >
               {article.title}
             </Link>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">{article.category}</Badge>
+              <span className="text-xs text-muted-foreground">
+                {new Date(article.date).toLocaleDateString('id-ID')}
+              </span>
+            </div>
             <p className="text-sm text-muted-foreground">{article.excerpt}</p>
           </li>
         ))}

--- a/src/app/components/ArticleCard.tsx
+++ b/src/app/components/ArticleCard.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArticleMeta } from '@/lib/articles';
+
+export function ArticleCard({ article }: { article: ArticleMeta }) {
+  return (
+    <Link
+      href={`/articles/${article.slug}`}
+      className="block bg-card rounded-lg overflow-hidden border border-border/50 hover:shadow-md transition-shadow"
+    >
+      <div className="relative w-full h-40">
+        <Image
+          src={article.thumbnail}
+          alt={article.title}
+          fill
+          sizes="100vw"
+          className="object-cover"
+        />
+      </div>
+      <div className="p-3 space-y-1">
+        <h3 className="font-semibold text-foreground line-clamp-2">
+          {article.title}
+        </h3>
+        <p className="text-sm text-muted-foreground line-clamp-2">
+          {article.excerpt}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,8 @@ import { ProductList } from "./components/ProductLinkCard";
 import { Product } from "./types/product";
 import { ProductCarousel } from "./components/ProductCarousel";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { ArticleCard } from "./components/ArticleCard";
+import { getArticleMeta } from "@/lib/articles";
 import productsData from "./data/products.json";
 
 export const metadata: Metadata = {
@@ -14,6 +16,9 @@ export const metadata: Metadata = {
 
 export default function Home() {
   const products: Product[] = productsData as Product[];
+  const projectArticles = getArticleMeta().filter(
+    (a) => a.category.toLowerCase() === "project"
+  );
   return (
     <div className="font-sans min-h-screen bg-background bg-[#F8F8F8] flex flex-col items-center px-4 transition-colors duration-300">
       <div className="bg-card w-full max-w-lg flex flex-col gap-2 md:w-full items-center mx-auto shadow-lg border border-border/50 p-4 rounded-lg">
@@ -27,6 +32,16 @@ export default function Home() {
             <ProductList products={products} />
           </div>
           <LinkList />
+          {projectArticles.length > 0 && (
+            <div className="mt-4 space-y-2">
+              <h2 className="text-lg font-bold text-foreground">Project Articles</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {projectArticles.map((article) => (
+                  <ArticleCard key={article.slug} article={article} />
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Copyright Section */}

--- a/src/content/articles/hello-world.md
+++ b/src/content/articles/hello-world.md
@@ -2,6 +2,8 @@
 title: "Hello World"
 date: "2024-01-01"
 excerpt: "Perkenalan singkat tentang project."
+category: "general"
+thumbnail: "/images/linkinbio.png"
 ---
 
 # Hello World

--- a/src/content/articles/second-post.md
+++ b/src/content/articles/second-post.md
@@ -2,6 +2,8 @@
 title: "Artikel Kedua"
 date: "2024-02-15"
 excerpt: "Penjelasan lanjutan mengenai fitur."
+category: "project"
+thumbnail: "/images/linkinbio.png"
 ---
 
 # Artikel Kedua

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -11,6 +11,8 @@ export interface ArticleMeta {
   title: string;
   date: string;
   excerpt: string;
+  category: string;
+  thumbnail: string;
 }
 
 export function getArticleSlugs(): string[] {
@@ -31,6 +33,8 @@ export function getArticleMeta(): ArticleMeta[] {
         title: data.title as string,
         date: data.date as string,
         excerpt: data.excerpt as string,
+        category: data.category as string,
+        thumbnail: data.thumbnail as string,
       } as ArticleMeta;
     })
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
@@ -47,6 +51,8 @@ export async function getArticleBySlug(slug: string): Promise<{ meta: ArticleMet
       title: data.title as string,
       date: data.date as string,
       excerpt: data.excerpt as string,
+      category: data.category as string,
+      thumbnail: data.thumbnail as string,
     },
     content: processedContent.toString(),
   };


### PR DESCRIPTION
### **User description**
## Summary
- include profile card and category badges on article pages
- add article category and thumbnail metadata
- display project category articles on the homepage

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825f125b3c8324b6624638fd4a7cf7


___

### **PR Type**
Enhancement


___

### **Description**
- Add article category and thumbnail metadata fields

- Include ProfileCard component on article pages

- Display project category articles on homepage

- Create ArticleCard component for article display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Article Metadata"] --> B["Add Category & Thumbnail"]
  B --> C["ProfileCard Integration"]
  C --> D["ArticleCard Component"]
  D --> E["Homepage Project Section"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

